### PR TITLE
Code fix/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,29 @@ A toolset to juggle AWS roles for persistent access
 # Usage
 First, use the find_cicular_trust.py tool to locate roles that create a circular trust. This is assuming the calling environment already has credentials loaded for the AWS environment:
 ```
-./find_circular_trust.py 
-Found cycle: ['arn:aws:iam::123456789:role/GitRole', 'arn:aws:iam::123456789:role/BuildRole', 'arn:aws:iam::123456789:role/ArtiRole']
+python find_circular_trust.py --profile lab
+[*] Found 1 cycle(s):
+ Cycle 1: arn:aws:iam::123456789:role/BuildRole -> arn:aws:iam::123456789:role/ArtiRole -> arn:aws:iam::123456789:role/BuildRole
+
+[+] Array for RoleJuggler (Compact):
+["arn:aws:iam::123456789:role/BuildRole","arn:aws:iam::123456789:role/ArtiRole"]
 ```
 Next, use the aws_role_juggler.py script to keep a role session alive for an indefinite period of time. In this example, we want to keep the BuildRole alive past the 1 hour max, so we provide the roles in the proper order:
 ```
-python aws_role_juggler.py -r arn:aws:iam::123456789:role/BuildRole arn:aws:iam::123456789:role/GitRole arn:aws:iam::123456789:role/ArtiRole
+ython aws_role_juggler.py --profile lab --role-list ["arn:aws:iam::123456789:role/BuildRole","arn:aws:iam::123456789:role/ArtiRole"]
+[*] Attempting to assume: arn:aws:iam::123456789:role/BuildRole
+[+] Successfully arn:aws:iam::123456789:role/BuildRole
+[*] Expiration: 2026-03-09 17:03:42+00:00
+
+export AWS_ACCESS_KEY_ID=ASIASFXXXXXXXXXXX
+export AWS_SECRET_ACCESS_KEY=UiyqqXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+export AWS_SESSION_TOKEN=IQoJb3JpZXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+[*] Juggling started. Press Ctrl+C at any time to skip the timer or exit.
+[*] Current Role: arn:aws:iam::123456789:role/BuildRole
+[*] Sleeping for 9m. (Ctrl+C for manual jump/exit)
 ```
-Even though the session is requested for an hour, it is refreshed every 15 minutes, and the credentials are output to screen.
+Even though the session is requested for an hour, it is refreshed every 10 minutes, and the credentials are output to screen.
 
 # TODO
 * Automatically detect cycles and best direction for aws_role_juggler.

--- a/aws_role_juggler.py
+++ b/aws_role_juggler.py
@@ -2,64 +2,104 @@
 
 from argparse import ArgumentParser
 import boto3
-import json
-import os
 import time
+import sys
 
-ACCESS_ID = "AWS_ACCESS_KEY_ID"
-SECRET_KEY = "AWS_SECRET_ACCESS_KEY"
-SESSION_KEY = "AWS_SESSION_TOKEN"
+def assume_role(client, arn):
+    print(f"[*] Attempting to assume: {arn}")
+    try:
+        response = client.assume_role(
+            RoleArn=arn,
+            RoleSessionName='juggle',
+            DurationSeconds=3600
+        )
 
-def assumeRole(client, arn):
-    response = client.assume_role (
-        RoleArn = arn,
-        RoleSessionName = 'juggle',
-        DurationSeconds = 3600
-    )
+        if not response or 'Credentials' not in response:
+            print(f"[!] Failed to assume {arn}. No credentials found.")
+            return None
+        
+        creds = response['Credentials']
+        print(f"[+] Successfully assumed {arn}")
+        print(f"[*] Expiration: {creds['Expiration']}")
+        
+        # Output for easy copy-pasting into environment variables
+        print(f"\nexport AWS_ACCESS_KEY_ID={creds['AccessKeyId']}")
+        print(f"export AWS_SECRET_ACCESS_KEY={creds['SecretAccessKey']}")
+        print(f"export AWS_SESSION_TOKEN={creds['SessionToken']}\n")
 
-    if not response:
-        print("[!] Failed to assume role. Exiting.")
-        return
-
-    if 'Credentials' not in response:
-        print("[!] No credentials returned. Exiting.")
-        return
+        session = boto3.Session(
+            aws_access_key_id=creds['AccessKeyId'],
+            aws_secret_access_key=creds['SecretAccessKey'],
+            aws_session_token=creds['SessionToken']
+        )
+        return session.client('sts')
     
-    credentials = response['Credentials']
-    print(f"[*] Expiration: {credentials['Expiration']}")
+    except Exception as e:
+        print(f"[!] Error: {e}")
+        return None
 
-    print(f"{credentials['AccessKeyId']}\n{credentials['SecretAccessKey']}\n{credentials['SessionToken']}\n")
+def juggle_roles(role_list, profile=None):
+    try:
+        session = boto3.Session(profile_name=profile)
+        client = session.client('sts')
+    except Exception as e:
+        print(f"[!] Initial session error: {e}")
+        sys.exit(1)
 
-    session = boto3.session.Session(aws_access_key_id=credentials['AccessKeyId'],
-                                    aws_secret_access_key = credentials['SecretAccessKey'],
-                                    aws_session_token=credentials['SessionToken'])
+    if not role_list:
+        print("[!] No roles provided.")
+        return
 
-    client= session.client('sts')
-    return client
+    # Start the chain
+    current_idx = 0
+    total_roles = len(role_list)
+    
+    # First jump
+    client = assume_role(client, role_list[current_idx])
+    if not client:
+        print("[!] Initial jump failed.")
+        return
 
-def juggleRoles(roleList):
-    client = boto3.client('sts') 
-
-    first_role = roleList.pop(0)
-    roleList.append(first_role)
-
-    client = assumeRole(client, first_role)
-    # Do the first role assumption
+    print("[*] Juggling started. Press Ctrl+C at any time to skip the timer or exit.")
 
     try:
-        while(True):
-            print("[*] Sleeping for 15 minutes and then refreshing session.")
-            time.sleep(540)
-            for role in roleList:
-                client = assumeRole(client, role)
+        while True:
+            try:
+                # Original logic: sleep for 9 minutes
+                print(f"[*] Current Role: {role_list[current_idx]}")
+                print("[*] Sleeping for 9m. (Ctrl+C for manual jump/exit)")
+                time.sleep(540)
+            except KeyboardInterrupt:
+                print("\n\n--- INTERRUPT ---")
+                choice = input("[?] [j]ump to next role / [q]uit script? ").lower().strip()
+                if choice == 'q':
+                    print("[*] Exiting...")
+                    return
+                print("[*] Jumping to next role in the cycle...")
+
+            # Move to the next role in the list (looping back to start if at the end)
+            current_idx = (current_idx + 1) % total_roles
+            next_role = role_list[current_idx]
+            
+            new_client = assume_role(client, next_role)
+            if new_client:
+                client = new_client
+            else:
+                print(f"[!] Jump to {next_role} failed. Retrying in next cycle.")
     
-    except KeyboardInterrupt:
-        return
- 
+    except Exception as e:
+        print(f"[!] Critical Error: {e}")
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = ArgumentParser(description="AWS Role Juggler with Manual Jump")
     parser.add_argument('-r', '--role-list', nargs='+', default=[])
+    parser.add_argument('-p', '--profile', help="Initial AWS profile", default=None)
     args = parser.parse_args()
 
-    juggleRoles(args.role_list)
+    # Clean input list from JSON-like strings
+    cleaned = []
+    for r in args.role_list:
+        r = r.replace('[','').replace(']','').replace('"','').replace("'", "")
+        cleaned.extend([i.strip() for i in r.split(',') if i.strip()])
+
+    juggle_roles(cleaned, args.profile)

--- a/find_circular_trust.py
+++ b/find_circular_trust.py
@@ -1,55 +1,108 @@
 #!/usr/bin/env python3
 
 import boto3
-import json
 import networkx as nx
+import argparse
+import sys
+import json
 
-def iam_list_roles():
-    iam_client = boto3.client('iam')
-    roles = []
-    response = {}
-    is_truncated = False
-
+def get_iam_client(profile_name=None):
     try:
-        while len(response.keys()) == 0 or is_truncated is True:
-            if is_truncated is False:
-                response = iam_client.list_roles()
-            else:
-                response = iam_client.list_roles(Marker=response['Marker'])
+        session = boto3.Session(profile_name=profile_name)
+        return session.client('iam')
+    except Exception as e:
+        print(f"[-] Error initializing session: {e}")
+        sys.exit(1)
 
-            for role in response['Roles']:
-                roles.append(role)
-
-            is_truncated = response['IsTruncated']
+def iam_list_roles(iam_client):
+    roles = []
+    paginator = iam_client.get_paginator('list_roles')
+    try:
+        for page in paginator.paginate():
+            roles.extend(page['Roles'])
         return roles
     except Exception as e:
-        raise
+        print(f"[-] Error listing roles: {e}")
+        return []
 
-def getCycles(aws_roles):
+def get_cycles(aws_roles):
     g = nx.DiGraph()
-    for role in aws_roles:
-        g.add_nodes_from([role["Arn"]])
+    all_role_arns = [role["Arn"] for role in aws_roles]
+    g.add_nodes_from(all_role_arns)
 
     for role in aws_roles:
-        for statement in role['AssumeRolePolicyDocument']['Statement']:
-            if statement['Effect'] == "Allow" and 'AWS' in statement['Principal']:
-                arns = statement['Principal']['AWS']
-                source = role['Arn']
-                if isinstance(arns, list):
-                    for arn in arns:
-                        dest = arn
-                        g.add_edges_from([(source, dest)])
-                else:
-                    dest = arns
-                    g.add_edges_from([(source, dest)])
+        target_role_arn = role['Arn']
+        policy = role.get('AssumeRolePolicyDocument', {})
+        statements = policy.get('Statement', [])
+        
+        if isinstance(statements, dict):
+            statements = [statements]
 
-    cycles = list(nx.simple_cycles(g))
-    return cycles
+        for stmt in statements:
+            if stmt.get('Effect') != "Allow":
+                continue
+
+            # 1. Extract direct Principals
+            principal = stmt.get('Principal', {})
+            aws_principals = principal.get('AWS', [])
+            if isinstance(aws_principals, str):
+                aws_principals = [aws_principals]
+
+            # 2. Extract ARNs from Conditions (Crucial for sts-lab-4)
+            condition_arns = []
+            condition = stmt.get('Condition', {})
+            for op in ['StringEquals', 'StringLike', 'ArnEquals', 'ArnLike']:
+                if op in condition:
+                    val = condition[op].get('aws:PrincipalArn', [])
+                    if isinstance(val, str): val = [val]
+                    condition_arns.extend(val)
+
+            # Combine trust sources
+            potential_sources = aws_principals + condition_arns
+
+            for source in potential_sources:
+                if source == "*":
+                    # If '*' with no ARN condition, all roles can assume this
+                    if not condition_arns:
+                        for other_role in all_role_arns:
+                            if other_role != target_role_arn:
+                                g.add_edge(other_role, target_role_arn)
+                elif source in all_role_arns:
+                    # Edge: source -> target_role (source can assume target)
+                    g.add_edge(source, target_role_arn)
+
+    return list(nx.simple_cycles(g))
 
 if __name__ == "__main__":
-    client = boto3.client('iam')
-    aws_roles = iam_list_roles()
+    parser = argparse.ArgumentParser(description="Find AWS IAM AssumeRole trust cycles.")
+    parser.add_argument("--profile", help="AWS CLI profile name", default=None)
+    parser.add_argument("--juggler", action="store_true", help="Output compact JSON array for AWSRoleJuggler")
+    args = parser.parse_args()
 
-    cycles = getCycles(aws_roles)
-    for c in cycles:
-        print(f"Found cycle: {c}")
+    iam = get_iam_client(args.profile)
+    roles = iam_list_roles(iam)
+    cycles = get_cycles(roles)
+    
+    if not cycles:
+        if args.juggler:
+            print("[]")
+        else:
+            print("[+] No trust cycles found.")
+    else:
+        # Extract unique roles involved in any cycle
+        roles_in_cycles = set()
+        for c in cycles:
+            roles_in_cycles.update(c)
+        
+        output_list = sorted(list(roles_in_cycles))
+
+        if args.juggler:
+            # separators=(',', ':') removes all whitespace from the JSON output
+            print(json.dumps(output_list, separators=(',', ':')))
+        else:
+            print(f"[*] Found {len(cycles)} cycle(s):")
+            for i, c in enumerate(cycles, 1):
+                print(f" Cycle {i}: {' -> '.join(c)} -> {c[0]}")
+            
+            print("\n[+] Array for RoleJuggler (Compact):")
+            print(json.dumps(output_list, separators=(',', ':')))


### PR DESCRIPTION
Summary
This PR introduces support for named AWS profiles and optimizes the role-switching workflow by allowing manual refresh overrides. It also includes updated documentation to reflect these changes.

Key Changes
aws_role_juggler.py & find_circular_trust.py:

New Feature: Added --profile argument support to utilize AWS named profiles as an alternative to environment variables.
Workflow Optimization: Implemented a mechanism to bypass the default 10-minute token refresh interval, enabling immediate jumps to the next role.

Bug Fix: Enhanced cycle detection within trusted_relationship statements to correctly handle complex conditional logic.



README.md:
Updated CLI usage examples to include the new --profile flag.

Added documentation for the manual refresh override feature.

Impact
Improves developer velocity by removing mandatory wait times between role transitions.

Provides more flexible credential management for multi-account environments.